### PR TITLE
Makes node type id replacement global

### DIFF
--- a/src/js/views/flows/red.js
+++ b/src/js/views/flows/red.js
@@ -7793,12 +7793,12 @@ RED.palette = (function() {
     }
 
     function escapeNodeType(nt) {
-        return nt.replace(" ","_").replace(".","_").replace(":","_");
+        return nt.replace(/ /g,"_").replace(/\./g,"_").replace(/:/g,"_");
     }
 
     function addNodeType(nt,def) {
         var nodeTypeId = escapeNodeType(nt);
-        if ($("#palette_node_"+nodeTypeId).length) {
+        if ($("#palette_node_" + nodeTypeId).length) {
             return;
         }
         if (exclusion.indexOf(def.category)===-1) {
@@ -7999,6 +7999,7 @@ RED.palette = (function() {
             }
         }
     }
+
     function hideNodeType(nt) {
         var nodeTypeId = escapeNodeType(nt);
         $("#palette_node_"+nodeTypeId).hide();


### PR DESCRIPTION
The id used when inserting the palette item in the DOM would be
generated on client-side with only the first (of perhaps many)
special character being handled, leading jQuery's selector query
to misbehave when the node id had multiple whitespaces. This fixes
that.

This fixes dojot/mashup#4 and prevents it from happening to other node types.