### PR TITLE
Fixes float regexp, Attr card title truncation

### DIFF
--- a/src/js/views/devices/new.js
+++ b/src/js/views/devices/new.js
@@ -242,7 +242,7 @@ class AttrCard extends Component {
         <div className="card z-depth-2">
           <div className="card-content row">
             <div className="col s10 main">
-              <div className="value title">{this.props.name}</div>
+              <div className="value title truncate">{this.props.name}</div>
               <div className="label">Name</div>
             </div>
             <div className="col s2">
@@ -361,7 +361,7 @@ class NewAttr extends Component {
         return result;
       },
       'float': function (value) {
-        const re = /^[+-]?\d+(.\d+)?$/
+        const re = /^[+-]?\d+(\.\d+)?$/
         const result = re.test(value);
         if (result == false) {
           ErrorActions.setField('value', 'This is not a float')


### PR DESCRIPTION
This fixes an issue where the regexp for float wouldn't handle
periods ('.') as literals thus allowing theh user to enter invalid
values.

Also, this fixes the truncation issue with attribute names on the
attribute list area of the device edition form/page.