### PR TITLE
Fixes device map view.

### DIFF
--- a/src/js/actions/MeasureActions.js
+++ b/src/js/actions/MeasureActions.js
@@ -62,7 +62,6 @@ class MeasureActions {
     }
 
     function parserPosition(position){
-      //console.log("Position: ", position.split(", "));
       let parsedPosition = position.split(", ");
       return [parseFloat(parsedPosition[0]), parseFloat(parsedPosition[1])];
     }
@@ -81,10 +80,10 @@ class MeasureActions {
 
       util._runFetch(getUrl(), config)
         .then((reply) => {
-          let position = {};
+          let position = null;
           let values = reply.contextResponses[0].contextElement.attributes[0].values;
           for(let k in values){
-            if(values[k].attrValue !== null || values[k].attrValue !== undefined){
+            if(values[k].attrValue !== null){
               position = parserPosition(values[k].attrValue);
             }
           }

--- a/src/js/views/devices/DeviceMap.js
+++ b/src/js/views/devices/DeviceMap.js
@@ -250,9 +250,7 @@ class DeviceMap extends Component {
       let parsedPosition = position.split(", ");
       return [parseFloat(parsedPosition[0]), parseFloat(parsedPosition[1])];
     }
-    //console.log("Devices: ", devices);
 
-    // verify if device is static
     let validDevices = [];
     for(let k in devices){
       for(let j in devices[k].attrs){
@@ -264,8 +262,12 @@ class DeviceMap extends Component {
           }
         }
       }
+
       devices[k].select = this.showSelected(k);
-      validDevices.push(devices[k]);
+      if(devices[k].position !== null){
+        validDevices.push(devices[k]);
+      }
+
     }
     return validDevices;
   }

--- a/src/js/views/devices/Devices.js
+++ b/src/js/views/devices/Devices.js
@@ -51,7 +51,7 @@ class MapWrapper extends Component {
         for(let i in devices[k].attrs[j]){
           if(devices[k].attrs[j][i].type == "dynamic"){
             if(devices[k].attrs[j][i].value_type == "geo"){
-                MeasureActions.fetchPosition.defer(devices[k], devices[k].id, devices[k].templates, devices[k].attrs[j][i].label, 10);
+                MeasureActions.fetchPosition.defer(devices[k], devices[k].id, devices[k].templates, devices[k].attrs[j][i].label, 1);
             }
           }
         }


### PR DESCRIPTION
The number of devices on the map (shown in the "Showing ..." label) is related to the number of devices that have published geolocation value. If a device is created but does not yet have a published geolocation value, that device does not appear on the map, so the number displayed on the label will not change.