### PR TITLE
Normalizes attribute serialization format

### DIFF
--- a/src/js/views/devices/new.js
+++ b/src/js/views/devices/new.js
@@ -128,6 +128,10 @@ class DeviceHandlerStore {
         return;
       }
 
+      if (attr_list[k].hasOwnProperty('value')) {
+        attr_list[k].static_value = attr_list[k].value;
+        delete attr_list[k].value;
+      }
       this.device.attrs.push(JSON.parse(JSON.stringify(attr_list[k])));
     }
    console.log("All attributes were set.", this.device);
@@ -479,15 +483,12 @@ class DeviceForm extends Component {
       .filter((i) => { return (String(i.type) == "static")|| (String(i.type) == "meta") })
       .map((attr) => {
         // check if there is a current static value in device store
-        if (attr.id)
-        {
+        if (attr.id) {
           if (this.props.device.attrNames[attr.id])
             attr.value = this.props.device.attrNames[attr.id];
           else
             attr.value = attr.static_value;
-        }
-        else
-        {
+        } else {
           attr.id = util.sid();
           attr.value = attr.static_value;
         }


### PR DESCRIPTION
First of all - I swear I only intended to change plumbing, not plaster.

This changes attribute serialization format to send values in their proper fields on the `attr` json object.
Along with some changes in device manager, this:
- is connected to dojot/dojot#271
- is connected to dojot/dojot#360