### PR TITLE
Updates status obtention scheme, fixes status initialization

### DIFF
--- a/src/js/stores/DeviceStore.js
+++ b/src/js/stores/DeviceStore.js
@@ -57,7 +57,7 @@ class DeviceStore {
     if (newDevice.static_attrs === undefined) {
       newDevice.static_attrs = [];
     }
-    // newDevice._status = this.parseStatus(device);
+
     newDevice.loading = false;
 
     this.devices[device.id] = newDevice;
@@ -66,9 +66,9 @@ class DeviceStore {
   }
 
   handleUpdateStatus(device) {
-   if (device.attrs.status != undefined) {
-    this.devices[device.metadata.deviceid].status = device.attrs.status;
-   }  
+   if (device.metadata.status != undefined) {
+    this.devices[device.metadata.deviceid].status = device.metadata.status;
+   }
   }
 
 
@@ -119,7 +119,9 @@ class DeviceStore {
         devices[idx].tags = [];
       }
 
-      devices[idx].status = "disabled";
+      if (devices[idx].status === undefined){
+        devices[idx].status = "disabled";
+      }
 
       this.devices[devices[idx].id] = JSON.parse(JSON.stringify(devices[idx]))
     }


### PR DESCRIPTION
This changes the status obtention (on websocket) field from `attrs` to metadata.
Also, this initializes devices' status with received last known status from backend.