### PR TITLE
Fixes template display for templates created via API

### DIFF
--- a/src/js/comms/devices/DeviceManager.js
+++ b/src/js/comms/devices/DeviceManager.js
@@ -6,7 +6,7 @@ class DeviceManager {
   }
 
   getDevices() {
-    return util.GET(this.baseUrl + '/device?page_size=1000');
+    return util.GET(this.baseUrl + '/device?page_size=1000&sortBy=label');
   }
 
   // @TODO probably here isn't a good place to handle stats

--- a/src/js/comms/templates/TemplateManager.js
+++ b/src/js/comms/templates/TemplateManager.js
@@ -5,14 +5,13 @@ class TemplateManager {
     this.baseUrl = ""
   }
 
-  getLastTemplates(field)
-  {
+  getLastTemplates(field) {
     return util.GET(this.baseUrl + "/template?limit=10&sortDsc="+field);
   }
 
   // @TO_CHECK are these names below correct?
   getTemplates() {
-    return util.GET(this.baseUrl + '/template');
+    return util.GET(this.baseUrl + '/template?limit=1000&sortBy=label');
   }
 
   getTemplate(id) {

--- a/src/js/stores/DeviceStore.js
+++ b/src/js/stores/DeviceStore.js
@@ -5,6 +5,7 @@ var TrackingActions = require('../actions/TrackingActions');
 class DeviceStore {
   constructor() {
     this.devices = {};
+    this.deviceList = [];
     this.tracking = {};
     this.error = null;
     this.loading = false;
@@ -124,6 +125,7 @@ class DeviceStore {
       }
 
       this.devices[devices[idx].id] = JSON.parse(JSON.stringify(devices[idx]))
+      this.deviceList[idx] = this.devices[devices[idx].id]
     }
 
     this.error = null;

--- a/src/js/views/devices/DeviceCard.js
+++ b/src/js/views/devices/DeviceCard.js
@@ -186,7 +186,7 @@ class DeviceCard extends Component {
             </div>
         </div>);
    } else {
-    this.filteredList = this.applyFiltering(this.props.devices);
+    this.filteredList = this.props.deviceList;
     this.clearInputField();
    }
       return (

--- a/src/js/views/templates/Templates.js
+++ b/src/js/views/templates/Templates.js
@@ -199,6 +199,7 @@ class AttributeList extends Component {
     }
 
     render() {
+        const staticValue = this.props.attributes.static_value || "";
         return (
             <div className={"attr-area " + (this.state.isSuppressed ? 'suppressed' : '')}>
                 <div className="attr-row">
@@ -239,8 +240,8 @@ class AttributeList extends Component {
                 <div className="attr-row">
                     <div className="icon"/>
                     <div className={"attr-content"}>
-                        <input className={this.state.fieldSizeStaticAttrStatus ? "truncate": ""} type="text" value={this.props.attributes.static_value} disabled={!this.props.editable}
-                               name={"static_value"} onChange={this.handleChange} maxLength="25" title={this.props.attributes.static_value}/>
+                        <input className={this.state.fieldSizeStaticAttrStatus ? "truncate": ""} type="text" value={staticValue} disabled={!this.props.editable}
+                               name={"static_value"} onChange={this.handleChange} maxLength="25" title={staticValue}/>
                         <select id="select_attribute_type" className="card-select mini-card-select"
                                 name={"type"}
                                 value={this.props.attributes.type}
@@ -276,8 +277,10 @@ class ConfigList extends Component {
     }
 
     componentWillMount(){
-        if(this.props.attributes.static_value.length > 18){
-            this.setState({configFieldSizeStatus: true});
+        if (this.props.attributes.hasOwnProperty('static_value')) {
+            if(this.props.attributes.static_value.length > 18){
+                this.setState({configFieldSizeStatus: true});
+            }
         }
     }
 
@@ -297,8 +300,11 @@ class ConfigList extends Component {
 
     render() {
         // console.log("this.props.attributes", this.props.attributes);
-        if (this.props.attributes.type == "fw_version")
-        return null;
+        if (this.props.attributes.type == "fw_version"){
+            return null;
+        }
+
+        const staticValue = this.props.attributes.static_value || '';
 
         return (
             <div className={"attr-area " + (this.state.isSuppressed ? 'suppressed' : '')}>
@@ -327,12 +333,12 @@ class ConfigList extends Component {
                     <div className="icon"/>
                     <div className={"attr-content"}>
                         <input className={(this.props.attributes.label === "protocol" ? 'none' : '') || (this.state.configFieldSizeStatus ? "truncate": "")}type="text"
-                               name={"static_value"} value={this.props.attributes.static_value}
-                               disabled={!this.props.editable} onChange={this.handleChange} title={this.props.attributes.static_value} maxLength="25"/>
+                               name={"static_value"} value={staticValue}
+                               disabled={!this.props.editable} onChange={this.handleChange} title={staticValue} maxLength="25"/>
                         <select id="select_attribute_type"
                                 className={(this.props.attributes.label === "protocol" ? '' : 'none') + " card-select"}
                                 name={"static_value"}
-                                value={this.props.attributes.static_value}
+                                value={staticValue}
                                 disabled={!this.props.editable}
                                 onChange={this.handleChange}>
                             <option value="">Select type</option>


### PR DESCRIPTION
When a user creates a template through the API, some fields might be left undefined, which is ok for dojot's backend, but currently causes some ruckus on GUI when listing templates.

This fixes this wanton behavior for templates.

----

Since `unfiltered` has no filters, to make things easier for the user, it's been requested that entity lists be ordered by their labels, allowing users to locate their target entries more easily. This also changes the way queries to the backend are constructed, to allow such behavior.