### PR TITLE
Small fixes for unfiltered branch

### DIFF
--- a/src/js/stores/DeviceStore.js
+++ b/src/js/stores/DeviceStore.js
@@ -67,7 +67,7 @@ class DeviceStore {
   }
 
   handleUpdateStatus(device) {
-   if (device.metadata.status != undefined) {
+   if ((device.metadata.status != undefined) && (this.devices[device.metadata.deviceid])) {
     this.devices[device.metadata.deviceid].status = device.metadata.status;
    }
   }

--- a/src/js/stores/MeasureStore.js
+++ b/src/js/stores/MeasureStore.js
@@ -75,7 +75,8 @@ class MeasureStore {
                                         "position": parserPosition(measureData.attrs[label]),
                                         "timestamp": util.iso_to_date(now)
                                     };
-                                    this.tracking[measureData.metadata.deviceid] = this.tracking[measureData.metadata.deviceid].concat(trackingStructure);
+                                    console.log(this.tracking);
+                                    this.tracking[measureData.metadata.deviceid].unshift(trackingStructure);
                                 }
                             } else {
                                 // attr is not geo

--- a/src/js/views/devices/Devices.js
+++ b/src/js/views/devices/Devices.js
@@ -104,7 +104,7 @@ class Devices extends Component {
 
       device_list_socket.on('error', (data) => {
         console.log("socket error", data);
-        socket.close();
+        device_list_socket.close();
         getWsToken();
       })
     }


### PR DESCRIPTION
This fixes an issue where websocket error handling would yield an invalid ref exception being thrown.

---

This fixes an issue where, should a status update event arrive before the list of devices is parsed, the status update would fail on `DeviceStore`