### PR TITLE
Fixes template editing

### DIFF
--- a/src/js/views/templates/Templates.js
+++ b/src/js/views/templates/Templates.js
@@ -634,6 +634,7 @@ class ListItem extends Component {
         this.toggleImageModal = this.toggleImageModal.bind(this);
         this.refreshImages = this.refreshImages.bind(this);
         this.updateDefaultVersion = this.updateDefaultVersion.bind(this);
+        this.removeAttributeId = this.removeAttributeId.bind(this);
     }
 
 
@@ -692,9 +693,17 @@ class ListItem extends Component {
         this.state.template.attrs.push.apply(this.state.template.attrs, this.state.template.data_attrs);
         this.state.template.attrs.push.apply(this.state.template.attrs ,this.state.template.config_attrs);
 
+        this.removeAttributeId(this.state.template);
+
         TemplateActions.triggerUpdate(this.state.template, (template) => {
           Materialize.toast('Template updated', 4000);
         });
+    }
+
+    removeAttributeId(template){
+        for(let index in template.attrs){
+            delete template.attrs[index].id;
+        }
     }
 
     deleteTemplate(e) {


### PR DESCRIPTION
In the editing of templates, the attribute id causes an error in the update. This PR removes this field in front. This field will be removed in backend too.

This PR is connected to dojot/dojot#467