### PR TITLE
Bug fix: Standardize the color of error messages in recovery password

### DIFF
--- a/src/js/containers/login/PasswordRecovery.js
+++ b/src/js/containers/login/PasswordRecovery.js
@@ -56,10 +56,10 @@ class Recovery extends Component {
         e.preventDefault();
         let validate = this.validate();
         if (validate === 1) {
-          toaster.critical('Password must be at least 8 characters')
+          toaster.error('Password must be at least 8 characters')
           this.setState({ invalid: {} });
         } else if(validate === 2){
-            toaster.critical('Password mismatch')
+            toaster.error('Password mismatch')
             this.setState({ invalid: {} });
         } else{
             const password = { passwd: this.state.password, token: this.state.token };


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
Different colors are being used for error messages in password registration.


* **What is the new behavior (if this is a feature change)?**
color of errors standardized


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This PR is connected to dojot/dojot#704.

* **Other information**:
