### PR TITLE
fix: copy image attrs to template object

### DIFF
--- a/src/js/views/templates/TemplateList/Sidebar/index.js
+++ b/src/js/views/templates/TemplateList/Sidebar/index.js
@@ -276,6 +276,7 @@ class Sidebar extends Component {
         template.attrs = [];
         template.attrs.push(...template.data_attrs);
         template.attrs.push(...template.config_attrs);
+        if (template.img_attrs) { template.attrs.push(...template.img_attrs); }
         template.attrs = this.removeIds(template.attrs);
         TemplateActions.triggerUpdate(template, () => {
             toaster.success(t('templates:alerts.update'));


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds a simple code to copy image attributes to the template object used to update itself.

This PR was tested in the following scenarios:
 - Saving meta attributes;
 - Image allowed or not when opened image's sidebar;
 - Updating meta attributes;
 - Saving in the main button;

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This PR is connected to dojot/dojot#959;

* **Other information**:
