### PR TITLE
feat: adding wrappers to permissions

### DIFF
--- a/src/js/components/importExport/ImportExportMain.js
+++ b/src/js/components/importExport/ImportExportMain.js
@@ -42,9 +42,8 @@ class ImportExportMain extends Component {
         const { openModal, toggleSidebar, t } = this.props;
         const { openImport } = this.state;
 
-        const canSeeImport = ability.can('modifier', 'import');
-        const canSeeExport = ability.can('viewer', 'export')
-            || ability.can('modifier', 'export');
+        const canSeeImport = ability.canModify('import');
+        const canSeeExport = ability.canView('export');
 
         return (
             <div>

--- a/src/js/components/permissions/ability.js
+++ b/src/js/components/permissions/ability.js
@@ -3,6 +3,11 @@ import Util from '../../comms/util/util';
 
 const ability = new Ability(Util.getPermissions() != null ? Util.getPermissions() : []);
 
+ability.canModify = permission => ability.can('modifier', permission);
+
+ability.canView = permission => ability.can('viewer', permission)
+    || ability.can('modifier', permission);
+
 export class AbilityUtil {
     static loginPermissions(permissions) {
         ability.update(permissions);

--- a/src/js/views/devices/DeviceCard.js
+++ b/src/js/views/devices/DeviceCard.js
@@ -14,7 +14,6 @@ import AltContainer from 'alt-container';
 import DeviceFormStore from './Store';
 import { FormActions } from "./Actions";
 
-import Can from 'Components/permissions/Can';
 import { withNamespaces } from 'react-i18next';
 import ability from 'Components/permissions/ability';
 
@@ -24,8 +23,10 @@ function SummaryItem(props) {
     for (const attribute in props.device.attrs) {
         attrs += props.device.attrs[attribute].length;
     }
-    const canEdit = ability.can('modifier', 'device');
-       return (
+    const canView = ability.canView('device');
+    const canEdit = ability.canModify('device');
+
+    return (
              <div className="mg20px fl flex-order-2">
                 <div className="card-size card-hover lst-entry-wrapper z-depth-2 mg0px pointer"  onClick={() => { if (canEdit) FormActions.set(props.device)}}>
                     <div className="lst-entry-title col s12">
@@ -36,11 +37,11 @@ function SummaryItem(props) {
                             </span>
                         </div>
                         <div className="title-edit" >
-                            <Can do="viewer" on="device">
+                            { canView ?
                                 <Link to={`/device/id/${props.device.id}/detail`}>
                                     <i title={props.t('devices:alts.details')} className="fa fa-info-circle fa-2x color-white" />
-                                </Link>
-                            </Can>
+                                </Link> : null
+                            }
                         </div>
                     </div>
                     <div className="attr-list">


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Was added two wrapper functions over Ability class: CanView and canModify. 
Now is possible to use the 'canView' method, checking also the viewer and modifier permission. 

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This PR is connected to dojot/dojot#1145

* **Other information**:
