### PR TITLE
Fix to display messages sent by API Gateway

### DIFF
--- a/src/js/actions/LoginActions.js
+++ b/src/js/actions/LoginActions.js
@@ -77,20 +77,30 @@ class LoginActions {
     }
 
     loginFailed(error) {
-        if (error === null) { return t('login:errors.not_found'); }
+        let errMsg = '';
 
-        if (error instanceof TypeError) {
-            return t('login:errors.no_connection');
+        if (error === null) {
+            errMsg = t('login:errors.not_found');
+        } else if (error instanceof TypeError) {
+            errMsg = t('login:errors.no_connection');
+        } else {
+            const status = (error.data.status) ? error.data.status : error.data.data.status;
+            if (status === 401 || status === 403) {
+                errMsg = t('login:errors.auth_failed');
+            } else if (status === 500) {
+                errMsg = t('login:errors.internal_error');
+            } else if (error.message) {
+                errMsg = error.message;
+            }
         }
 
-        const { data } = error;
-        if ((data.status === 401) || (data.status === 403)) {
-            return t('login:errors.auth_failed');
+        if (errMsg === '') {
+            errMsg = t('login:errors.not_found');
         }
-        if (data.status === 500) {
-            return t('login:errors.internal_error');
-        }
-        return t('login:errors.not_found');
+
+        toaster.error(errMsg);
+
+        return errMsg;
     }
 }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

[#1259](https://github.com/dojot/dojot/issues/1259)

* **What is the new behavior (if this is a feature change)?**

--

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

--

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

this issue was originated by:
[#873](https://github.com/dojot/dojot/issues/873)

* **Other information**:

When the token is no longer valid, the error data is within a second 'data' attrib (error.data.data), 
see commit diff: src/js/actions/LoginActions.js, line 87.
The gateway returns a 404 error and the message 'API not found'.
