### PR TITLE
[issue#1146] Warning Message Always Visible in Top

### DIFF
--- a/locales/en/flows.json
+++ b/locales/en/flows.json
@@ -9,7 +9,8 @@
     "create": "Flow created.",
     "remove": "Flow removed.",
     "failed_find_ctx": "failed to find flow context.",
-    "maybe_not_saved": "Don't forget to save your updates."
+    "maybe_not_saved": "Don't forget to save your updates.",
+    "work_is_not_saved_ask_to_confirm_exit": "Your work is not saved! Are you sure you want to leave?"
   },
   "last_update": "Last update",
   "nodes": "Nodes",

--- a/locales/en/flows.json
+++ b/locales/en/flows.json
@@ -8,7 +8,8 @@
     "update": "Flow updated.",
     "create": "Flow created.",
     "remove": "Flow removed.",
-    "failed_find_ctx": "failed to find flow context."
+    "failed_find_ctx": "failed to find flow context.",
+    "maybe_not_saved": "Don't forget to save your updates."
   },
   "last_update": "Last update",
   "nodes": "Nodes",

--- a/locales/pt-br/flows.json
+++ b/locales/pt-br/flows.json
@@ -8,7 +8,8 @@
     "update": "Fluxo alterado.",
     "create": "Fluxo criado.",
     "remove": "Fluxo removido.",
-    "failed_find_ctx": "falha ao procurar o contexto do fluxo."
+    "failed_find_ctx": "falha ao procurar o contexto do fluxo.",
+    "maybe_not_saved": "Não esqueça de salvar suas atualizações."
   },
   "last_update": "Ultima atualização",
   "nodes": "Nós",

--- a/locales/pt-br/flows.json
+++ b/locales/pt-br/flows.json
@@ -9,7 +9,8 @@
     "create": "Fluxo criado.",
     "remove": "Fluxo removido.",
     "failed_find_ctx": "falha ao procurar o contexto do fluxo.",
-    "maybe_not_saved": "Não esqueça de salvar suas atualizações."
+    "maybe_not_saved": "Não esqueça de salvar suas atualizações.",
+    "work_is_not_saved_ask_to_confirm_exit": "Seu trabalho não está salvo! Você tem certeza de que quer sair?"
   },
   "last_update": "Ultima atualização",
   "nodes": "Nós",

--- a/src/js/views/flows/edit.js
+++ b/src/js/views/flows/edit.js
@@ -362,6 +362,7 @@ class EditFlowComponent extends Component {
             return "Discard changes?";
         };
     }
+
     disableBeforeUnload() {
         window.onbeforeunload = null;
     }
@@ -405,8 +406,7 @@ class EditFlowComponent extends Component {
     }
 
     componentWillUnmount() {
-        // required to disable onbeforeunload window behavior
-        this.somethingChanged(true);
+        this.disableBeforeUnload();
     }
 
     render() {

--- a/src/js/views/flows/edit.js
+++ b/src/js/views/flows/edit.js
@@ -208,7 +208,7 @@ var observer = {};
 
 const MutationSchema = ({ somethingChanged, isSaved }) => {
     var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
-    
+
     if (isSaved === false)
     {
         // if we already know that we should save, let's disconnect the observer
@@ -222,24 +222,24 @@ const MutationSchema = ({ somethingChanged, isSaved }) => {
         }, 3000);
         alreadySetted = true;
     }
-        
+
     function setMutation()
     {
         var target1 = document.querySelector('#chart>svg');
         //var target2 = document.querySelector('.editor-tray.ui-draggable');
         if (target1)
         {
-            observer = new MutationObserver(function(mutations) {  
+            observer = new MutationObserver(function(mutations) {
                 mutations.forEach(function(mutation) {
                     // sending false means isSaved = false;
                     somethingChanged(false);
                 });
            });
-    
+
             var config = {
-                attributes: true, 
+                attributes: true,
                 characterData: true
-            }; 
+            };
             observer.observe(target1, config);
             //if (target2)
             //    observer.observe(target2, config);
@@ -346,7 +346,7 @@ class EditFlowComponent extends Component {
     somethingChanged(newState)
     {
         const isSaved = newState;
-        if (isSaved)        
+        if (isSaved)
             this.disableBeforeUnload();
         else
             this.enableBeforeUnload();
@@ -406,14 +406,13 @@ class EditFlowComponent extends Component {
                     <div
                         className="row valign-wrapper absolute-input full-width no-margin top-minus-2 "
                     >
-                        
-                        {(!isSaved ?  
-                            <Slide right duration={300}>
-                                <div className="maybeNotSaved"> 
+                        <Slide right duration={300}>
+                                <div className="maybeNotSaved">
                                 <div className="boxLine"></div>
-                                <span>Don't forget to save your updates.</span>
+                                <span>{i18n('flows:alerts.maybe_not_saved')}</span>
                                 <i className="fa fa-exclamation-triangle" ></i>
-                        </div> </Slide>: null )}
+                            </div>
+                        </Slide>
                         <AltContainer store={FlowStore}>
                             <NameForm t={i18n} />
                         </AltContainer>

--- a/src/sass/_flows.scss
+++ b/src/sass/_flows.scss
@@ -6,16 +6,16 @@
   right: 240px;
   z-index: 1000;
   font-weight: 600;
-  color: #ce1b1b;
-  background-color: #fbeaea;
+  color: #2f2f2f;
+  background-color: #ffd300;
   -webkit-transition: width 2s; /* Safari */
   transition: width 2s;
   height: 38px;
-  width: 310px;
+  width: 360px;
 
   .boxLine{
     position: absolute;
-    background: #eb5757;
+    background: #c1c1c1;
     width:3px;
     height: 100%;
     left: 0;
@@ -34,7 +34,7 @@
     font-size: 19px;
     position: absolute;
     right: 5px;
-    top: 2px;
+    top: 5px;
     padding: 5px;
   }
 }


### PR DESCRIPTION
Treatment to keep warning message (referring to save flow) always visible on top.

The control that was to display or not the warning was removed, so the message will always be displayed.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR aims to keep the flow warning message always visible at the top.
Its a temporary solution to work around the problem that exists when the user leaves the flow screen without realizing that it had not yet been saved.

* **What is the current behavior?** (You can also link to an open issue here)

When you exit the flow screen, the unsaved flow is lost.

* **What is the new behavior (if this is a feature change)?**

When you leave the unsaved flow screen, the unsaved flow is lost, but a highlight message is always present at the top to remind you.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

none

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

dojot/dojot#1146 

* **Other information**:

Warning message is no longer red, now it is yellow.

The message had not been internationalized, now it is.