### PR TITLE
fix: Fixed component that use web socket real time data

### DIFF
--- a/src/js/views/devices/detail.js
+++ b/src/js/views/devices/detail.js
@@ -780,6 +780,8 @@ class ViewDeviceComponent extends Component {
     constructor(props) {
         super(props);
 
+        const { params } = this.props;
+
         this.socketBaseURL = `${window.location.protocol}//${window.location.host}`;
         this.tokenURL = `${this.socketBaseURL}/stream/socketio`;
         this.keepConnected = true;
@@ -791,7 +793,7 @@ class ViewDeviceComponent extends Component {
             reconnection: false,
         });
 
-        this.socket.on('all', (data) => {
+        this.socket.on(`${params.device}`, (data) => {
             MeasureActions.appendMeasures(data);
         }).on('error', () => {
             // if the socket was connected, the 'close()' method

--- a/src/js/views/devices/detail.js
+++ b/src/js/views/devices/detail.js
@@ -793,23 +793,18 @@ class ViewDeviceComponent extends Component {
 
         this.socket.on('all', (data) => {
             MeasureActions.appendMeasures(data);
-        }).on('error', (error) => {
-            // console.log('[dojot-socket.io] on \'error\', error: ', error);
-
+        }).on('error', () => {
             // if the socket was connected, the 'close()' method
             // will fire the event 'disconnect' and manually reconnect
             this.socket.close();
 
-        }).on('connect_error', (error) => {
-            // console.log('[dojot-socket.io] on \'connect_error\', error: ', error);
+        }).on('connect_error', () => {
             this.socketReconnection();
 
-        }).on('connect_timeout', (timeout) => {
-            // console.log('[dojot-socket.io] on \'connect_timeout\', timeout: ', timeout);
+        }).on('connect_timeout', () => {
             this.socketReconnection();
 
-        }).on('disconnect', (reason) => {
-            // console.log('[dojot-socket.io] on \'disconnect\', reason: ', reason);
+        }).on('disconnect', () => {
             this.socketReconnection();
         });
     }
@@ -835,9 +830,6 @@ class ViewDeviceComponent extends Component {
                     token: reply.token
                 }
                 selfSocket.open();
-            })
-            .catch((error) => {
-                // console.log('Failed!', error);
             });
     }
 


### PR DESCRIPTION
The SocketIO client was incorporated as an attribute of the ViewDeviceComponent component,
now it is initialized in the react component constructor, but does not automatically
establish a web socket connection, it is now manual and is only established when the
component is mounted by React. Similarly, the connection is terminated when the component
is unmounted by React. If there are any errors terminating the connection to the
SocketIO Server, reconnection is done manually because a new one-time token must
be generated before reconnecting.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix
Upon losing communication with the server, Socket.IO-Client attempted to reconnect automatically, but Data Broker required a new One-Time Token and the connection was broken and real-time data was no longer updated in the GUI.

* **What is the current behavior?** (You can also link to an open issue here)

dojot/dojot#1346

* **What is the new behavior (if this is a feature change)?**

The reconnection is done manually and managed by the React component. When a connection is lost, a new One-Time Token is first requested and then re-established via SocketIO.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

dojot/dojot#1346

* **Other information**:
